### PR TITLE
JigConfigのdocumentTypesの指定方法を修正

### DIFF
--- a/jig-gradle-plugin/README.md
+++ b/jig-gradle-plugin/README.md
@@ -35,7 +35,7 @@ jigReports.dependsOn(compileJava)
 ## 設定(値はデフォルト)
 ```
 jig {
-    documentTypes = ['ServiceMethodCallHierarchy','PackageDependency','ClassList']
+    documentTypes = ['ServiceMethodCallHierarchy','PackageDependency','ApplicationList','DomainList','BranchList','EnumUsage','BooleanService']
     outputDirectory = 'build/jig' //出力ディレクトリ
     outputOmitPrefix= '.+\\.(service|domain\\.(model|basic))\\.' //出力時に省略する接頭辞パターン
     depth = -1 //出力する最大のパッケージ階層(-1は制限なし）


### PR DESCRIPTION
`org.dddjava.jig.presentation.view.report.JigDocument`のenumに一致させるため