### PR TITLE
Scala用のAlias取得拡張部分を追加

### DIFF
--- a/jig-core/src/main/java/org/dddjava/jig/application/service/AliasService.java
+++ b/jig-core/src/main/java/org/dddjava/jig/application/service/AliasService.java
@@ -8,6 +8,7 @@ import org.dddjava.jig.domain.model.jigsource.source.code.AliasSource;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.JavaSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.PackageInfoSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSources;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
 import org.springframework.stereotype.Service;
 
 /**
@@ -69,6 +70,14 @@ public class AliasService {
         loadAliases(typeAliases);
     }
 
+    /**
+     * ScalaDocから別名を取り込む
+     */
+    void loadAliases(ScalaSources scalaSources) {
+        TypeAliases typeAliases = reader.readScalaSources(scalaSources);
+        loadAliases(typeAliases);
+    }
+
     private void loadAliases(TypeAliases typeAliases) {
         for (TypeAlias typeAlias : typeAliases.list()) {
             repository.register(typeAlias);
@@ -82,6 +91,7 @@ public class AliasService {
     public void loadAliases(AliasSource aliasSource) {
         loadAliases(aliasSource.javaSources());
         loadAliases(aliasSource.kotlinSources());
+        loadAliases(aliasSource.scalaSources());
         loadPackageAliases(aliasSource.packageInfoSources());
     }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/declaration/method/Arguments.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/declaration/method/Arguments.java
@@ -3,6 +3,7 @@ package org.dddjava.jig.domain.model.declaration.method;
 import org.dddjava.jig.domain.model.declaration.type.TypeIdentifier;
 import org.dddjava.jig.domain.model.declaration.type.TypeIdentifiers;
 
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.stream.Collectors.joining;
@@ -16,6 +17,10 @@ public class Arguments {
 
     public Arguments(List<TypeIdentifier> argumentTypes) {
         this.argumentTypes = argumentTypes;
+    }
+
+    public static Arguments empty() {
+        return new Arguments(Collections.emptyList());
     }
 
     String argumentsAsText() {

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigloaded/alias/ScalaSourceAliasReader.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigloaded/alias/ScalaSourceAliasReader.java
@@ -1,0 +1,12 @@
+package org.dddjava.jig.domain.model.jigloaded.alias;
+
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
+
+/**
+ * ScalaSourceから別名を読み取る
+ */
+public interface ScalaSourceAliasReader {
+
+    TypeAliases readAlias(ScalaSources sources);
+
+}

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigloaded/alias/SourceCodeAliasReader.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigloaded/alias/SourceCodeAliasReader.java
@@ -3,6 +3,7 @@ package org.dddjava.jig.domain.model.jigloaded.alias;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.JavaSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.PackageInfoSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSources;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
 
 /**
  * コードを使用する別名別名読み取り機
@@ -11,14 +12,24 @@ public class SourceCodeAliasReader {
 
     JavaSourceAliasReader javaSourceAliasReader;
     KotlinSourceAliasReader kotlinSourceAliasReader;
+    ScalaSourceAliasReader scalaSourceAliasReader;
 
     public SourceCodeAliasReader(JavaSourceAliasReader javaSourceAliasReader) {
-        this(javaSourceAliasReader, sources -> TypeAliases.empty());
+        this(javaSourceAliasReader, sources -> TypeAliases.empty(), sources -> TypeAliases.empty());
     }
 
     public SourceCodeAliasReader(JavaSourceAliasReader javaSourceAliasReader, KotlinSourceAliasReader kotlinSourceAliasReader) {
+        this(javaSourceAliasReader, kotlinSourceAliasReader, sources -> TypeAliases.empty());
+    }
+
+    public SourceCodeAliasReader(JavaSourceAliasReader javaSourceAliasReader, ScalaSourceAliasReader scalaSourceAliasReader) {
+        this(javaSourceAliasReader, sources -> TypeAliases.empty(), scalaSourceAliasReader);
+    }
+
+    private SourceCodeAliasReader(JavaSourceAliasReader javaSourceAliasReader, KotlinSourceAliasReader kotlinSourceAliasReader, ScalaSourceAliasReader scalaSourceAliasReader) {
         this.javaSourceAliasReader = javaSourceAliasReader;
         this.kotlinSourceAliasReader = kotlinSourceAliasReader;
+        this.scalaSourceAliasReader = scalaSourceAliasReader;
     }
 
     public PackageAliases readPackages(PackageInfoSources packageInfoSources) {
@@ -31,5 +42,9 @@ public class SourceCodeAliasReader {
 
     public TypeAliases readKotlinSources(KotlinSources kotlinSources) {
         return kotlinSourceAliasReader.readAlias(kotlinSources);
+    }
+
+    public TypeAliases readScalaSources(ScalaSources scalaSources) {
+        return scalaSourceAliasReader.readAlias(scalaSources);
     }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/AliasSource.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/AliasSource.java
@@ -6,6 +6,8 @@ import org.dddjava.jig.domain.model.jigsource.source.code.javacode.PackageInfoSo
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.PackageInfoSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSource;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSources;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSource;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,20 +19,22 @@ public class AliasSource {
 
     JavaSources javaSources;
     KotlinSources kotlinSources;
+    ScalaSources scalaSources;
     PackageInfoSources packageInfoSources;
 
     public AliasSource(CodeSource codeSource) {
-        this(codeSource.javaSources, codeSource.kotlinSources, codeSource.packageInfoSources);
+        this(codeSource.javaSources, codeSource.kotlinSources, codeSource.scalaSources, codeSource.packageInfoSources);
     }
 
-    public AliasSource(JavaSources javaSources, KotlinSources kotlinSources, PackageInfoSources packageInfoSources) {
+    public AliasSource(JavaSources javaSources, KotlinSources kotlinSources, ScalaSources scalaSources, PackageInfoSources packageInfoSources) {
         this.javaSources = javaSources;
         this.kotlinSources = kotlinSources;
+        this.scalaSources = scalaSources;
         this.packageInfoSources = packageInfoSources;
     }
 
     public AliasSource() {
-        this(new JavaSources(), new KotlinSources(), new PackageInfoSources());
+        this(new JavaSources(), new KotlinSources(), new ScalaSources(), new PackageInfoSources());
     }
 
     public JavaSources javaSources() {
@@ -39,6 +43,10 @@ public class AliasSource {
 
     public KotlinSources kotlinSources() {
         return kotlinSources;
+    }
+
+    public ScalaSources scalaSources() {
+        return scalaSources;
     }
 
     public PackageInfoSources packageInfoSources() {
@@ -50,8 +58,10 @@ public class AliasSource {
         javaSources.addAll(other.javaSources.list());
         List<KotlinSource> kotlinSources = new ArrayList<>(this.kotlinSources.list());
         kotlinSources.addAll(other.kotlinSources.list());
+        List<ScalaSource> scalaSources = new ArrayList<>(this.scalaSources.list());
+        scalaSources.addAll(other.scalaSources.list());
         List<PackageInfoSource> packageInfoSources = new ArrayList<>(this.packageInfoSources.list());
         packageInfoSources.addAll(other.packageInfoSources.list());
-        return new AliasSource(new JavaSources(javaSources), new KotlinSources(kotlinSources), new PackageInfoSources(packageInfoSources));
+        return new AliasSource(new JavaSources(javaSources), new KotlinSources(kotlinSources), new ScalaSources(scalaSources), new PackageInfoSources(packageInfoSources));
     }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/CodeSource.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/CodeSource.java
@@ -3,15 +3,18 @@ package org.dddjava.jig.domain.model.jigsource.source.code;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.JavaSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.PackageInfoSources;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSources;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
 
 public class CodeSource {
     JavaSources javaSources;
     KotlinSources kotlinSources;
+    ScalaSources scalaSources;
     PackageInfoSources packageInfoSources;
 
-    public CodeSource(JavaSources javaSources, KotlinSources kotlinSources, PackageInfoSources packageInfoSources) {
+    public CodeSource(JavaSources javaSources, KotlinSources kotlinSources, ScalaSources scalaSources, PackageInfoSources packageInfoSources) {
         this.javaSources = javaSources;
         this.kotlinSources = kotlinSources;
+        this.scalaSources = scalaSources;
         this.packageInfoSources = packageInfoSources;
     }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/CodeSourceFile.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/CodeSourceFile.java
@@ -2,6 +2,7 @@ package org.dddjava.jig.domain.model.jigsource.source.code;
 
 import org.dddjava.jig.domain.model.jigsource.source.code.javacode.JavaSourceFile;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSourceFile;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSourceFile;
 
 import java.nio.file.Path;
 
@@ -22,5 +23,9 @@ public class CodeSourceFile {
 
     public KotlinSourceFile asKotlin() {
         return new KotlinSourceFile(path);
+    }
+
+    public ScalaSourceFile asScala() {
+        return new ScalaSourceFile(path);
     }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSource.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSource.java
@@ -1,0 +1,31 @@
+package org.dddjava.jig.domain.model.jigsource.source.code.scalacode;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * .scalaソース
+ */
+public class ScalaSource {
+
+    ScalaSourceFile scalaSourceFile;
+    byte[] value;
+
+    public ScalaSource(ScalaSourceFile scalaSourceFile, byte[] value) {
+        this.scalaSourceFile = scalaSourceFile;
+        this.value = value;
+    }
+
+    public ScalaSourceFile sourceFilePath() {
+        return scalaSourceFile;
+    }
+
+    public InputStream toInputStream() {
+        return new ByteArrayInputStream(value);
+    }
+
+    @Override
+    public String toString() {
+        return "ScalaSource[" + scalaSourceFile + "]";
+    }
+}

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSourceFile.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSourceFile.java
@@ -1,0 +1,21 @@
+package org.dddjava.jig.domain.model.jigsource.source.code.scalacode;
+
+import java.nio.file.Path;
+
+public class ScalaSourceFile {
+    Path path;
+    String fileName;
+
+    public ScalaSourceFile(Path path) {
+        this.path = path;
+        this.fileName = path.getFileName().toString();
+    }
+
+    public String fineName() {
+        return fileName;
+    }
+
+    public boolean isScala() {
+        return fileName.endsWith(".scala");
+    }
+}

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSources.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/ScalaSources.java
@@ -1,0 +1,24 @@
+package org.dddjava.jig.domain.model.jigsource.source.code.scalacode;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * .scalaソース一覧
+ */
+public class ScalaSources {
+
+    List<ScalaSource> list;
+
+    public ScalaSources(List<ScalaSource> list) {
+        this.list = list;
+    }
+
+    public ScalaSources() {
+        this(Collections.emptyList());
+    }
+
+    public List<ScalaSource> list() {
+        return list;
+    }
+}

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/package-info.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/jigsource/source/code/scalacode/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Scalaが書かれているファイル
+ */
+package org.dddjava.jig.domain.model.jigsource.source.code.scalacode;

--- a/jig-core/src/main/java/org/dddjava/jig/infrastructure/filesystem/LocalFileSourceReader.java
+++ b/jig-core/src/main/java/org/dddjava/jig/infrastructure/filesystem/LocalFileSourceReader.java
@@ -11,6 +11,9 @@ import org.dddjava.jig.domain.model.jigsource.source.code.javacode.*;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSource;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSourceFile;
 import org.dddjava.jig.domain.model.jigsource.source.code.kotlincode.KotlinSources;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSource;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSourceFile;
+import org.dddjava.jig.domain.model.jigsource.source.code.scalacode.ScalaSources;
 import org.objectweb.asm.ClassReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +68,7 @@ public class LocalFileSourceReader implements SourceReader {
             try {
                 List<JavaSource> javaSources = new ArrayList<>();
                 List<KotlinSource> kotlinSources = new ArrayList<>();
+                List<ScalaSource> scalaSources = new ArrayList<>();
                 List<PackageInfoSource> packageInfoSources = new ArrayList<>();
                 Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
                     @Override
@@ -73,6 +77,7 @@ public class LocalFileSourceReader implements SourceReader {
                             CodeSourceFile codeSourceFile = new CodeSourceFile(file);
                             JavaSourceFile javaSourceFile = codeSourceFile.asJava();
                             KotlinSourceFile kotlinSourceFile = codeSourceFile.asKotlin();
+                            ScalaSourceFile scalaSourceFile = codeSourceFile.asScala();
                             if (javaSourceFile.isJava()) {
                                 JavaSource javaSource = new JavaSource(javaSourceFile, Files.readAllBytes(file));
                                 if (javaSourceFile.isPackageInfo()) {
@@ -83,6 +88,9 @@ public class LocalFileSourceReader implements SourceReader {
                             } else if (kotlinSourceFile.isKotlin()) {
                                 KotlinSource kotlinSource = new KotlinSource(kotlinSourceFile, Files.readAllBytes(file));
                                 kotlinSources.add(kotlinSource);
+                            } else if (scalaSourceFile.isScala()) {
+                                ScalaSource scalaSource = new ScalaSource(scalaSourceFile, Files.readAllBytes(file));
+                                scalaSources.add(scalaSource);
                             }
 
                             return FileVisitResult.CONTINUE;
@@ -91,7 +99,7 @@ public class LocalFileSourceReader implements SourceReader {
                         }
                     }
                 });
-                list.add(new CodeSource(new JavaSources(javaSources), new KotlinSources(kotlinSources), new PackageInfoSources(packageInfoSources)));
+                list.add(new CodeSource(new JavaSources(javaSources), new KotlinSources(kotlinSources), new ScalaSources(scalaSources), new PackageInfoSources(packageInfoSources)));
             } catch (IOException e) {
                 LOGGER.warn("skipped '{}'. (type={}, message={})", path, e.getClass().getName(), e.getMessage());
             }


### PR DESCRIPTION
# 概要
- JigをScalaプロジェクトをターゲットに指定したうえで実行すると、Scalaのソースコードの解析処理が未実装であったため、別名が取得できていませんでした。
- 今回、ひとまず、 `Class/Trait/Object` について別名を取得できるように対応しました。

# やったこと
- `jig-core` プロジェクトに、Scalaのソースを解析して別名を取り込む処理の流れと枠組みを追加しました。

# 確認したこと
- `jig-core` がbuildできること
- 別ブランチで、 `jig-cli-scala` プロジェクトを追加して動作確認し、必要な拡張が足りているか検証した
  - 別ブランチで実施した理由は、 #423 に経緯あり。
