### PR TITLE
出力されたhtmlファイルの左メニュー下部見切れを修正

### DIFF
--- a/jig-core/src/main/resources/templates/assets/style.css
+++ b/jig-core/src/main/resources/templates/assets/style.css
@@ -6,6 +6,10 @@ a:hover {
     text-decoration-line: underline;
 }
 
+body {
+    margin: 0 8px;
+}
+
 .menu {
     /* box-sizing: border-box; */
     position: fixed;


### PR DESCRIPTION
ブラウザの幅よりも縦に長いメニューの場合、メニューを下までスクロールすると末尾の単語が見切れる現象を修正
#727 