### PR TITLE
Refactor method signature handling and improve generics support

### DIFF
--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/data/classes/method/MethodSignature.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/data/classes/method/MethodSignature.java
@@ -46,7 +46,7 @@ public final class MethodSignature {
      * @see #asSimpleText()
      */
     public String asText() {
-        var argumentsText = arguments.stream().map(ParameterizedType::typeIdentifier).map(TypeIdentifier::fullQualifiedName).collect(joining(", "));
+        var argumentsText = arguments.stream().map(ParameterizedType::asFullNameText).collect(joining(", "));
         return methodName + "(" + argumentsText + ")";
     }
 

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/data/classes/type/ParameterizedType.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/data/classes/type/ParameterizedType.java
@@ -27,6 +27,15 @@ public record ParameterizedType(TypeIdentifier typeIdentifier, List<Parameterize
         return typeIdentifier;
     }
 
+    public String asFullNameText() {
+        if (_typeParameters.isEmpty()) {
+            return typeIdentifier.fullQualifiedName();
+        }
+        return typeIdentifier.fullQualifiedName() + _typeParameters.stream()
+                .map(ParameterizedType::asFullNameText)
+                .collect(Collectors.joining(", ", "<", ">"));
+    }
+
     public String asSimpleText() {
         if (_typeParameters.isEmpty()) {
             return typeIdentifier.asSimpleText();

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/information/jigobject/member/JigMethod.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/information/jigobject/member/JigMethod.java
@@ -240,4 +240,8 @@ public class JigMethod {
     private String usecaseMermaidNodeText() {
         return "%s([\"%s\"])".formatted(htmlIdText(), labelTextOrLambda());
     }
+
+    public String name() {
+        return declaration().methodSignature().methodName();
+    }
 }

--- a/jig-core/src/main/java/org/dddjava/jig/infrastructure/asm/AsmMethodSignatureVisitor.java
+++ b/jig-core/src/main/java/org/dddjava/jig/infrastructure/asm/AsmMethodSignatureVisitor.java
@@ -4,12 +4,14 @@ import org.dddjava.jig.domain.model.data.classes.method.MethodDeclaration;
 import org.dddjava.jig.domain.model.data.classes.method.MethodReturn;
 import org.dddjava.jig.domain.model.data.classes.method.MethodSignature;
 import org.dddjava.jig.domain.model.data.classes.type.TypeIdentifier;
+import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -69,7 +71,7 @@ class AsmMethodSignatureVisitor extends SignatureVisitor {
         return super.visitExceptionType();
     }
 
-    MethodDeclaration methodDeclaration(TypeIdentifier declaringType, String methodName) {
+    public MethodDeclaration buildMethodDeclaration(TypeIdentifier declaringType, String methodName) {
         return new MethodDeclaration(
                 declaringType,
                 MethodSignature.from(
@@ -80,5 +82,16 @@ class AsmMethodSignatureVisitor extends SignatureVisitor {
                 ),
                 new MethodReturn(returnVisitor.generateParameterizedType())
         );
+    }
+
+    static Optional<MethodDeclaration> buildMethodDeclaration(int api, String name, TypeIdentifier declaringType, String signature) {
+        try {
+            AsmMethodSignatureVisitor methodSignatureVisitor = new AsmMethodSignatureVisitor(api);
+            new SignatureReader(signature).accept(methodSignatureVisitor);
+            return Optional.of(methodSignatureVisitor.buildMethodDeclaration(declaringType, name));
+        } catch (Exception e) {
+            logger.warn("exception occurred reading method signature {} for {} {}", signature, declaringType, name, e);
+            return Optional.empty();
+        }
     }
 }

--- a/jig-core/src/test/java/org/dddjava/jig/infrastructure/asm/AsmMethodSignatureVisitorTest.java
+++ b/jig-core/src/test/java/org/dddjava/jig/infrastructure/asm/AsmMethodSignatureVisitorTest.java
@@ -48,7 +48,7 @@ class AsmMethodSignatureVisitorTest {
         logger.debug("read signature:{}", actualSignature);
         new SignatureReader(actualSignature).accept(sut);
 
-        MethodDeclaration methodDeclaration = sut.methodDeclaration(TypeIdentifier.from(JigSupportMethodSignatureImplementations.class), methodName);
+        MethodDeclaration methodDeclaration = sut.buildMethodDeclaration(TypeIdentifier.from(JigSupportMethodSignatureImplementations.class), methodName);
 
         assertEquals(expectedJigMethodSignatureSimpleText, methodDeclaration.asSignatureAndReturnTypeSimpleText());
     }


### PR DESCRIPTION
This pull request introduces several changes to improve analysis and representation of method signatures:

- Refactored to use `AsmMethodSignatureVisitor` for reading method signatures.
- Enhanced `MethodSignature#asText` to construct argument strings using `ParameterizedType#asFullNameText`, ensuring better clarity and consistency when dealing with parameterized types.
- Added a failing (RED) test case to address handling of generic arguments, improving test coverage. 

These changes collectively aim to enhance the robustness of method signature processing.