### PR TITLE
デフォルトパッケージを対象にした場合のパッケージ関連図出力できない問題を解消

### DIFF
--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/data/packages/PackageIdentifier.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/data/packages/PackageIdentifier.java
@@ -67,6 +67,13 @@ public class PackageIdentifier {
         return value;
     }
 
+    public Optional<PackageIdentifier> parentIfExist() {
+        PackageIdentifier parent = parent();
+        if (parent.value.equals("(default)")) return Optional.empty();
+        return Optional.of(parent);
+    }
+
+    // TODO (default) がでてきた場合にを型で識別できないので、使わないようにした方が良さそう
     public PackageIdentifier parent() {
         String[] split = value.split("\\.");
 

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/documents/stationery/Labeler.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/documents/stationery/Labeler.java
@@ -29,7 +29,9 @@ public class Labeler {
 
     public String label(PackageIdentifier packageIdentifier) {
         String fqn = packageIdentifier.asText();
-        String labelText = commonPrefix.map(String::length).map(index -> trimDot(fqn.substring(index)))
+        String labelText = commonPrefix
+                .filter(fqn::startsWith)
+                .map(prefix -> trimDot(fqn.substring(prefix.length())))
                 .orElse(fqn);
 
         return addAliasIfExists(packageIdentifier, labelText);

--- a/jig-core/src/main/java/org/dddjava/jig/domain/model/documents/stationery/Labeler.java
+++ b/jig-core/src/main/java/org/dddjava/jig/domain/model/documents/stationery/Labeler.java
@@ -61,8 +61,13 @@ public class Labeler {
         // 全てで共通する部分を抜き出す
         String commonPrefix = null;
         for (PackageIdentifier currentPackageIdentifier : contextPackages) {
-            PackageIdentifier currentParentPackageIdentifier = currentPackageIdentifier.parent();
-            String currentText = currentParentPackageIdentifier.asText();
+            Optional<PackageIdentifier> packageIdentifier = currentPackageIdentifier.parentIfExist();
+            if (packageIdentifier.isEmpty()) {
+                continue;
+            }
+            String currentText = packageIdentifier.orElseThrow().asText();
+
+            packageIdentifier.map(PackageIdentifier::asText);
             if (commonPrefix == null) {
                 commonPrefix = currentText;
                 continue;
@@ -80,7 +85,7 @@ public class Labeler {
 
             commonPrefix = commonPrefix.substring(0, commonPrefixLength);
         }
-        this.commonPrefix = Optional.of(trimDot(commonPrefix));
+        this.commonPrefix = Optional.ofNullable(commonPrefix).map(this::trimDot);
     }
 
     public String contextDescription() {

--- a/jig-core/src/test/java/org/dddjava/jig/domain/model/documents/diagrams/PackageRelationDiagramTest.java
+++ b/jig-core/src/test/java/org/dddjava/jig/domain/model/documents/diagrams/PackageRelationDiagramTest.java
@@ -98,6 +98,22 @@ class PackageRelationDiagramTest {
                         List.of(
                                 "\"a.aa\" -> \"b\";"
                         )
+                ),
+                Arguments.argumentSet("デフォルトパッケージを扱える",
+                        new PackageIdentifiers(List.of(
+                                PackageIdentifier.valueOf("a.aa.aaa.aaaa.aaaaa"),
+                                PackageIdentifier.valueOf("a.aa.aaa.aaaa.aaaab"),
+                                PackageIdentifier.defaultPackage(),
+                                PackageIdentifier.valueOf("a")
+                        )),
+                        new ClassRelations(List.of(
+                                new ClassRelation(TypeIdentifier.valueOf("a.aa.aaa.aaaa.aaaaa.Hoge"), TypeIdentifier.valueOf("a.aa.aaa.aaaa.aaaab.Fuga")),
+                                new ClassRelation(TypeIdentifier.valueOf("a.aa.aaa.aaaa.aaaaa.Hoge"), TypeIdentifier.valueOf("DefaultPackageClass"))
+                        )),
+                        4,
+                        List.of(
+                                "\"a.aa.aaa.aaaa\" -> \"(default)\";"
+                        )
                 )
         );
     }

--- a/jig-core/src/test/java/org/dddjava/jig/domain/model/documents/diagrams/PackageRelationDiagramTest.java
+++ b/jig-core/src/test/java/org/dddjava/jig/domain/model/documents/diagrams/PackageRelationDiagramTest.java
@@ -83,6 +83,21 @@ class PackageRelationDiagramTest {
                                 "\"a.aa.aaa\" -> \"b\";",
                                 "subgraph \"cluster_a.aa\""
                         )
+                ),
+                Arguments.argumentSet("階層がずれた関連を1階層切り詰める",
+                        new PackageIdentifiers(List.of(
+                                PackageIdentifier.valueOf("a.aa.aaa"),
+                                PackageIdentifier.valueOf("a.aa.aab.aaba"),
+                                PackageIdentifier.valueOf("b")
+                        )),
+                        new ClassRelations(List.of(
+                                new ClassRelation(TypeIdentifier.valueOf("a.aa.aaa.Foo"), TypeIdentifier.valueOf("a.aa.aab.aaba.Bar")),
+                                new ClassRelation(TypeIdentifier.valueOf("a.aa.aaa.Foo"), TypeIdentifier.valueOf("b.Bbb"))
+                        )),
+                        2,
+                        List.of(
+                                "\"a.aa\" -> \"b\";"
+                        )
                 )
         );
     }


### PR DESCRIPTION
しました。
デフォルトパッケージとか使わない方がいいよ。